### PR TITLE
Fix init-db.py import path

### DIFF
--- a/bin/init-db.py
+++ b/bin/init-db.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add app directory to Python path
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from webapp.database import init_db, DATABASE_PATH
 


### PR DESCRIPTION
- Adjust sys.path to parent directory to find webapp module
- Fixes ModuleNotFoundError when running from Docker

🤖 Generated with [Claude Code](https://claude.ai/code)