### PR TITLE
Keep minimum 1 machine always running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,7 +18,7 @@ kill_timeout = 5
   protocol = "tcp"
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[services.ports]]
     port = 80


### PR DESCRIPTION
Set min_machines_running to 1 to prevent app from autostopping completely