### PR TITLE
Fix database path to use mounted volume

### DIFF
--- a/bin/bridge_openings_sync.py
+++ b/bin/bridge_openings_sync.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import os
 import sys
 
-DB_FILE = "bridgeping.db"
+DB_FILE = os.environ.get('DATABASE_PATH', '/app/data/bridgeping.db')
 URL = "https://opendata.ndw.nu/brugopeningen.xml.gz"
 TEMP_FILE = "brugopeningen.xml.gz"
 

--- a/bin/enhance_bridge_locations.py
+++ b/bin/enhance_bridge_locations.py
@@ -4,8 +4,9 @@ import requests
 import json
 import time
 from collections import defaultdict
+import os
 
-DB_FILE = "bridgeping.db"
+DB_FILE = os.environ.get('DATABASE_PATH', '/app/data/bridgeping.db')
 
 def add_location_columns():
     """Add columns for enhanced location data."""

--- a/bin/fetch_osm_bridges.py
+++ b/bin/fetch_osm_bridges.py
@@ -4,8 +4,9 @@ import json
 import sqlite3
 import time
 from datetime import datetime
+import os
 
-DB_FILE = "bridgeping.db"
+DB_FILE = os.environ.get('DATABASE_PATH', '/app/data/bridgeping.db')
 
 def create_bridges_table():
     """Create table for static bridge data from OSM."""


### PR DESCRIPTION
- Update all bin scripts to use DATABASE_PATH environment variable
- Default to /app/data/bridgeping.db when env var not set
- Ensures database is written to persistent volume at /app/data/
- Fixes issue where database was being written to /app/bridgeping.db