### PR TITLE
Update calendar subscription link to use webcal protocol

### DIFF
--- a/webapp/templates/bridges_city.html
+++ b/webapp/templates/bridges_city.html
@@ -37,7 +37,7 @@
                     </div>
                     
                     <div class="d-flex justify-content-between align-items-center">
-                        <a href="/calendar/bridge/{{ bridge.id }}.ics" class="btn btn-primary btn-sm">
+                        <a href="webcal://{{ request.url.netloc }}/calendar/bridge/{{ bridge.id }}.ics" class="btn btn-primary btn-sm">
                             <i class="bi bi-calendar-plus"></i> Subscribe to Calendar
                         </a>
                         


### PR DESCRIPTION
- Changed calendar link in bridges_city.html to use webcal:// protocol
- Matches the behavior of the dashboard subscription link

🤖 Generated with [Claude Code](https://claude.ai/code)